### PR TITLE
Make cached_property act like builtin property

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,15 +87,15 @@ def test_cached_property():
     assert foo == [42]
 
 
-def test_cannot_set_cached_property():
+def test_can_set_cached_property():
     class A(object):
         @utils.cached_property
         def _prop(self):
             return 'cached_property return value'
 
     a = A()
-    with pytest.raises(AttributeError):
-        a._prop = 'value'
+    a._prop = 'value'
+    assert a._prop == 'value'
 
 def test_inspect_treats_cached_property_as_property():
     class A(object):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ import pytest
 
 from datetime import datetime
 from functools import partial
+import inspect
 
 from werkzeug import utils
 from werkzeug.datastructures import Headers
@@ -84,6 +85,29 @@ def test_cached_property():
     q = a.prop
     assert p == q == 42
     assert foo == [42]
+
+
+def test_cannot_set_cached_property():
+    class A(object):
+        @utils.cached_property
+        def _prop(self):
+            return 'cached_property return value'
+
+    a = A()
+    with pytest.raises(AttributeError):
+        a._prop = 'value'
+
+def test_inspect_treats_cached_property_as_property():
+    class A(object):
+        @utils.cached_property
+        def _prop(self):
+            return 'cached_property return value'
+
+    attrs = inspect.classify_class_attrs(A)
+    for attr in attrs:
+        if attr.name == '_prop':
+            break
+    assert attr.kind == 'property'
 
 def test_environ_property():
     class A(object):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -386,7 +386,7 @@ def test_stream_wrapping():
     data = b'foo=Hello+World'
     req = wrappers.Request.from_values('/', method='POST', data=data,
         content_type='application/x-www-form-urlencoded')
-    req.__dict__['stream'] = LowercasingStream(req.stream)
+    req.stream = LowercasingStream(req.stream)
     assert req.form['foo'] == 'hello world'
 
 def test_data_descriptor_triggers_parsing():

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -386,7 +386,7 @@ def test_stream_wrapping():
     data = b'foo=Hello+World'
     req = wrappers.Request.from_values('/', method='POST', data=data,
         content_type='application/x-www-form-urlencoded')
-    req.stream = LowercasingStream(req.stream)
+    req.__dict__['stream'] = LowercasingStream(req.stream)
     assert req.form['foo'] == 'hello world'
 
 def test_data_descriptor_triggers_parsing():

--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -61,6 +61,9 @@ class cached_property(property):
         self.__doc__ = doc or func.__doc__
         self.func = func
 
+    def __set__(self, obj, value):
+        obj.__dict__[self.__name__] = value
+
     def __get__(self, obj, type=None):
         if obj is None:
             return self

--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -32,7 +32,7 @@ _windows_device_files = ('CON', 'AUX', 'COM1', 'COM2', 'COM3', 'COM4', 'LPT1',
                          'LPT2', 'LPT3', 'PRN', 'NUL')
 
 
-class cached_property(object):
+class cached_property(property):
     """A decorator that converts a function into a lazy property.  The
     function wrapped is called the first time to retrieve the result
     and then that calculated result is used the next time you access
@@ -49,13 +49,11 @@ class cached_property(object):
     work.
     """
 
-    # implementation detail: this property is implemented as non-data
-    # descriptor.  non-data descriptors are only invoked if there is
-    # no entry with the same name in the instance's __dict__.
-    # this allows us to completely get rid of the access function call
-    # overhead.  If one choses to invoke __get__ by hand the property
-    # will still work as expected because the lookup logic is replicated
-    # in __get__ for manual invocation.
+    # implementation detail: A subclass of python's builtin property
+    # decorator, we override __get__ to check for a cached value. If one
+    # choses to invoke __get__ by hand the property will still work as
+    # expected because the lookup logic is replicated in __get__ for
+    # manual invocation.
 
     def __init__(self, func, name=None, doc=None):
         self.__name__ = name or func.__name__


### PR DESCRIPTION
* cached_property cannot not be set as if it were an attribute
* inspect will treat cached_property as a subclass of the builtin
property
* Fixes issue #616 