### PR TITLE
Catch UnicodeDecodeError, fixes #640

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1141,7 +1141,12 @@ class Map(object):
             subdomain = self.default_subdomain
         if script_name is None:
             script_name = '/'
-        server_name = _encode_idna(server_name)
+
+        try:
+            server_name = _encode_idna(server_name)
+        except:
+            server_name = None
+
         return MapAdapter(self, server_name, script_name, subdomain,
                           url_scheme, path_info, default_method, query_args)
 

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -113,14 +113,25 @@ def host_is_trusted(hostname, trusted_list):
             hostname = hostname.rsplit(':', 1)[0]
         return _encode_idna(hostname)
 
-    hostname = _normalize(hostname)
+    # hostname is required to contain only ascii
+    try:
+        hostname = _normalize(hostname)
+    except ValueError:
+        return False
+
     for ref in trusted_list:
         if ref.startswith('.'):
             ref = ref[1:]
             suffix_match = True
         else:
             suffix_match = False
-        ref = _normalize(ref)
+
+        # If ref is not ascii, skip it.
+        try:
+            ref = _normalize(ref)
+        except ValueError:
+            continue
+
         if ref == hostname:
             return True
         if suffix_match and hostname.endswith('.' + ref):


### PR DESCRIPTION
Fix proposal for issue #640 

`_encode_idna` is called from four places in werkzeug

```bash
$> git grep _encode_idna | grep -vE '(import|def)'
werkzeug/_internal.py:    domain = _encode_idna(domain)
werkzeug/routing.py:            server_name = _encode_idna(server_name)
werkzeug/urls.py:            rv = _encode_idna(rv)
werkzeug/wsgi.py:        return _encode_idna(hostname)
```

* **_internal.py**: called by `_make_cookie_domain`. I don't know when `_make_cookie_domain` is called or why. The patch proposed doesn't fix a issue here.

* **routing.py**: called by `Map.bind` with `server_name` as attr. The patch sets `server_name` to `None` if `_encode_idna` fails. I don't know if it generates side effects.

* **urls.py**: called by `BaseURL.ascii_host`. The patch doesn't fix anything here, I don't know if it needs to.

* **wsgi.py**: called by `host_is_trusted` on both arguments `hostname` and `trusted_list`. If `hostname` is not only ASCII, `host_is_trusted` returns False. If an entry of `host_is_trusted` is not only ASCII, the comparison against it is skipped.