### PR TITLE
Fix inheritance with Rule.empty

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -568,7 +568,7 @@ class Rule(RuleFactory):
         defaults = None
         if self.defaults:
             defaults = dict(self.defaults)
-        return Rule(self.rule, defaults, self.subdomain, self.methods,
+        return type(self)(self.rule, defaults, self.subdomain, self.methods,
                     self.build_only, self.endpoint, self.strict_slashes,
                     self.redirect_to, self.alias, self.host)
 


### PR DESCRIPTION
Rule.empty() always returned an instance of werkzeug.routing.Rule
even when a Rule subclass existed. This patch ensures that the
new instance of the rule returned by empty() is always an instance
of the class the rule is an instance of.