### PR TITLE
Fix pruning elements from SimpleCache in python3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -92,7 +92,10 @@ Version 0.9.7
   object (pull request ``#583``).
 - The ``qop`` parameter for ``WWW-Authenticate`` headers is now always quoted,
   as required by RFC 2617 (issue ``#633``).
-
+- Fix bug in ``werkzeug.contrib.cache.SimpleCache`` with Python 3 where add/set 
+  may throw an exception when pruning old entries from the cache (pull request
+  ``#650``).
+  
 Version 0.9.6
 -------------
 

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -259,9 +259,12 @@ class SimpleCache(BaseCache):
     def _prune(self):
         if len(self._cache) > self._threshold:
             now = time()
+            toremove = []
             for idx, (key, (expires, _)) in enumerate(self._cache.items()):
                 if expires <= now or idx % 3 == 0:
-                    self._cache.pop(key, None)
+                    toremove.append(key)
+            for key in toremove:
+                self._cache.pop(key, None)
 
     def get(self, key):
         try:


### PR DESCRIPTION
Hi, I noticed that an exception was being thrown when using the SimpleCache in python 3
  File "werkzeug/contrib/cache.py", line 262, in _prune
    for idx, (key, (expires, _)) in enumerate(self._cache.items()):
  RuntimeError: dictionary changed size during iteration
when running a sample test
  from werkzeug.contrib import cache
  c = cache.SimpleCache(threshold=2)
  c.set("1", "1")
  c.set("2", "2")
  c.set("3", "3")
  c.set("4", "4")
since in python3, the iterator is now a view into the original dict rather than a copy (unlike python2), so an error is thrown when trying to remove keys in the _prune method. 

I've modified it to keep a list of elements to remove instead, and remove them after iteration; is that okay? 

Thanks,
Jin