### PR TITLE
Added new rule factory: UrlSuffix

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -303,6 +303,10 @@ def test_rule_templates():
           r.Subdomain('$app',
           [ r.Rule('/blah', endpoint='x_bar')
           , r.Rule('/meh', endpoint='x_baz')
+          ]),
+          r.UrlSuffix('.$app',
+          [ r.Rule('/spam', endpoint='pyspam'),
+            r.Rule('/spameggs', endpoint='pyspameggs')
           ])
         ])
 
@@ -325,6 +329,14 @@ def test_rule_templates():
         ('/meh', 'test2', 'x_baz'),
         ('/meh', 'test3', 'x_baz'),
         ('/meh', 'test4', 'x_baz'),
+        ('/spam.test1', '', 'pyspam'),
+        ('/spam.test2', '', 'pyspam'),
+        ('/spam.test3', '', 'pyspam'),
+        ('/spam.test4', '', 'pyspam'),
+        ('/spameggs.test1', '', 'pyspameggs'),
+        ('/spameggs.test2', '', 'pyspameggs'),
+        ('/spameggs.test3', '', 'pyspameggs'),
+        ('/spameggs.test4', '', 'pyspameggs'),
         ('/test/test1/bar/', '', 'handle_bar'),
         ('/test/test1/baz/', '', 'handle_baz'),
         ('/test/test1/foo/', '', 'handle_foo'),

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -330,6 +330,31 @@ class Submount(RuleFactory):
                 yield rule
 
 
+class UrlSuffix(RuleFactory):
+    """Like `Subdomain` but suffixes the URL rule with a given string::
+
+        url_map = Map([
+            Rule('/', endpoint='index'),
+            UrlSuffix('.json', [
+                Rule('/blog', endpoint='json/blog/index')
+            ])
+        ])
+
+    Now the rule ``'json/blog/index'`` matches ``/blog.json``.
+    """
+
+    def __init__(self, suffix, rules):
+        self.suffix = suffix
+        self.rules = rules
+
+    def get_rules(self, map):
+        for rulefactory in self.rules:
+            for rule in rulefactory.get_rules(map):
+                rule = rule.empty()
+                rule.rule = rule.rule + self.suffix
+                yield rule
+
+
 class EndpointPrefix(RuleFactory):
     """Prefixes all endpoints (which must be strings for this factory) with
     another string. This can be useful for sub applications::


### PR DESCRIPTION
It works like `Subdomain` and `Submount`, but adds a string to the end of the url instead.

This can be useful if we already have a list of rules that are used on one set of endpoints, and this, combined with `EndpointPrefix`, can be used like this:

    EndpointPrefix('json/', [UrlSuffix('.json', my_rules)])

to create another similar set of rules.