### PR TITLE
keep an eventlet-friendly reference to time.sleep

### DIFF
--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -107,8 +107,13 @@ def _find_common_roots(paths):
 
 
 class ReloaderLoop(object):
-    _sleep = time.sleep  # monkeypatched by testsuite
+
     name = None
+
+    # monkeypatched by testsuite
+    @staticmethod
+    def _sleep(secs):
+        time.sleep(secs)
 
     def __init__(self, extra_files=None, interval=1):
         self.extra_files = set(os.path.abspath(x)

--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -110,7 +110,12 @@ class ReloaderLoop(object):
 
     name = None
 
-    # monkeypatched by testsuite
+    # monkeypatched by testsuite. this used to just say `_sleep = time.sleep`,
+    # but because c functions behave differently to python functions when
+    # attached to classes, this breaks if sleep has been already replaced with
+    # a python function (e.g. by eventlet.monkey_patch). python functions are
+    # descriptors and become methods when attahed to classes, whereas c
+    # functions remain as functions (thus behaving like staticmethods)
     @staticmethod
     def _sleep(secs):
         time.sleep(secs)


### PR DESCRIPTION
otherwise, when eventlet.monkey_patch replaces time.sleep,
this raises a TypeError when called, since while adding the builtin
sleep to the ReloaderLoop we stil end up with a function, but when
replaced, we end up with a method, which now expects a self argument.