### PR TITLE
Fix regression from #660

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -439,6 +439,16 @@ def test_build_append_multiple():
     assert a == 'http://example.org/bar/0.815'
     assert set(b.split('&')) == set('pof=2.0&bif=1.0&bif=3.0'.split('&'))
 
+    params = {
+        'bazf': 0.815,
+        'bif': [1.0, 3.0],
+        'pof': 2.0,
+    }
+    a, b = adapter.build('barf', params).split('?')
+    assert a == 'http://example.org/bar/0.815'
+    assert set(b.split('&')) == set('pof=2.0&bif=1.0&bif=3.0'.split('&'))
+
+
 def test_method_fallback():
     map = r.Map([
         r.Rule('/', endpoint='index', methods=['GET']),

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1637,10 +1637,9 @@ class MapAdapter(object):
         """
         self.map.update()
         if values:
-            if isinstance(values, MultiDict):
-                valueiter = iteritems(values, multi=True)
-            else:
-                valueiter = iteritems(values)
+            if isinstance(values, dict):
+                values = MultiDict(values)
+            valueiter = iteritems(values, multi=True)
             values = MultiDict((k, v) for k, v in valueiter if v is not None)
         else:
             values = {}


### PR DESCRIPTION
After updating to 0.10, I'm having issues with `url_for` in Flask, which I have traced to the changes made in #660. As noted by @davidism [here](https://github.com/mitsuhiko/werkzeug/issues/658#issuecomment-72022911) the behavior that #660 was trying to add was kindof already supported:

with `werkzeug==0.9.6`

```python
app = flask.Flask(__name__)
@app.route('/')
def index():
    return '42'

flask.url_for('index', x=[1, 2])  # '/?x=1&x=2'
```

with `werkzeug==0.10`

```python
flask.url_for('index', x=[1, 2])  # '/?x=%5B1%2C+2%5D'
```

This PR will convert `dict` to `MultiDict` so that both will work now.