### PR TITLE
Added reloader_modules option

### DIFF
--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -9,7 +9,7 @@ from werkzeug._internal import _log
 from werkzeug._compat import PY2, iteritems, text_type
 
 
-def _iter_module_files():
+def _iter_module_files(reloader_modules):
     """This iterates over all relevant Python files.  It goes through all
     loaded files from modules, all files in folders of already loaded modules
     as well as all files reachable through a package.
@@ -53,36 +53,45 @@ def _iter_module_files():
         except OSError:
             pass
 
-    # The list call is necessary on Python 3 in case the module
-    # dictionary modifies during iteration.
-    for path_entry in list(sys.path):
-        for filename in _recursive_walk(os.path.abspath(path_entry)):
-            yield filename
-
-    for module in list(sys.modules.values()):
-        if module is None:
-            continue
-        filename = _verify_file(getattr(module, '__file__', None))
-        if filename:
-            yield filename
-            for filename in _recursive_walk(os.path.dirname(filename)):
-                yield filename
-        for package_path in getattr(module, '__path__', ()):
-            for filename in _recursive_walk(os.path.abspath(package_path)):
+    if reloader_modules=='auto':
+        # The list call is necessary on Python 3 in case the module
+        # dictionary modifies during iteration.
+        for path_entry in list(sys.path):
+            for filename in _recursive_walk(os.path.abspath(path_entry)):
                 yield filename
 
+        for module in list(sys.modules.values()):
+            if module is None:
+                continue
+            filename = _verify_file(getattr(module, '__file__', None))
+            if filename:
+                yield filename
+                for filename in _recursive_walk(os.path.dirname(filename)):
+                    yield filename
+            for package_path in getattr(module, '__path__', ()):
+                for filename in _recursive_walk(os.path.abspath(package_path)):
+                    yield filename
+    else:
+        for path_entry in reloader_modules:
+            for filename in _recursive_walk(os.path.abspath(path_entry)):
+                yield filename
 
-def _find_observable_paths(extra_files=None):
+
+def _find_observable_paths(reloader_modules, extra_files=None):
     """Finds all paths that should be observed."""
-    rv = set(os.path.abspath(x) for x in sys.path)
+    if reloader_modules=='auto':
+        rv = set(os.path.abspath(x) for x in sys.path)
+        for module in list(sys.modules.values()):
+            fn = getattr(module, '__file__', None)
+            if fn is None:
+                continue
+            fn = os.path.abspath(fn)
+            rv.add(os.path.dirname(fn))
+    else:
+        rv = set(os.path.abspath(x) for x in reloader_modules)
     for filename in extra_files or ():
         rv.append(os.path.dirname(os.path.abspath(filename)))
-    for module in list(sys.modules.values()):
-        fn = getattr(module, '__file__', None)
-        if fn is None:
-            continue
-        fn = os.path.abspath(fn)
-        rv.add(os.path.dirname(fn))
+
     return rv
 
 
@@ -114,7 +123,8 @@ class ReloaderLoop(object):
     # `eventlet.monkey_patch`) before we get here
     _sleep = staticmethod(time.sleep)
 
-    def __init__(self, extra_files=None, interval=1):
+    def __init__(self, reloader_modules, extra_files=None, interval=1):
+        self.reloader_modules = reloader_modules
         self.extra_files = set(os.path.abspath(x)
                                for x in extra_files or ())
         self.interval = interval
@@ -156,7 +166,7 @@ class StatReloaderLoop(ReloaderLoop):
     def run(self):
         mtimes = {}
         while 1:
-            for filename in chain(_iter_module_files(), self.extra_files):
+            for filename in chain(_iter_module_files(self.reloader_modules), self.extra_files):
                 try:
                     mtime = os.stat(filename).st_mtime
                 except OSError:
@@ -220,7 +230,7 @@ class WatchdogReloaderLoop(ReloaderLoop):
         while not self.should_reload:
             to_delete = set(watches)
             paths = _find_common_roots(
-                _find_observable_paths(self.extra_files))
+                _find_observable_paths(self.reloader_modules, self.extra_files))
             for path in paths:
                 if path not in watches:
                     try:
@@ -256,10 +266,10 @@ else:
 
 
 def run_with_reloader(main_func, extra_files=None, interval=1,
-                      reloader_type='auto'):
+                      reloader_type='auto', reloader_modules='auto'):
     """Run the given function in an independent python interpreter."""
     import signal
-    reloader = reloader_loops[reloader_type](extra_files, interval)
+    reloader = reloader_loops[reloader_type](reloader_modules, extra_files, interval)
     signal.signal(signal.SIGTERM, lambda *args: sys.exit(0))
     try:
         if os.environ.get('WERKZEUG_RUN_MAIN') == 'true':

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -524,7 +524,7 @@ def is_running_from_reloader():
 def run_simple(hostname, port, application, use_reloader=False,
                use_debugger=False, use_evalex=True,
                extra_files=None, reloader_interval=1,
-               reloader_type='auto', reloader_modules='auto', threaded=False,
+               reloader_type='auto', reloader_modules=None, threaded=False,
                processes=1, request_handler=None, static_files=None,
                passthrough_errors=False, ssl_context=None):
     """Start a WSGI application. Optional features include a reloader,
@@ -567,9 +567,9 @@ def run_simple(hostname, port, application, use_reloader=False,
     :param reloader_type: the type of reloader to use.  The default is
                           auto detection.  Valid values are ``'stat'`` and
                           ``'watchdog'``.
-    :param reloader_modules: modules the reloader should watch.  The default is
-                          to automatically detect files (``'auto'``).
-                          Valid values are ``'auto'`` or a list of paths.
+    :param reloader_modules: modules the reloader should watch.  Defaults to
+                             ``None`` which means automatically detect modules.
+                             Valid values are a list of paths or ``None``.
     :param threaded: should the process handle each request in a separate
                      thread?
     :param processes: if greater than 1 then handle each request in a new process

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -524,8 +524,8 @@ def is_running_from_reloader():
 def run_simple(hostname, port, application, use_reloader=False,
                use_debugger=False, use_evalex=True,
                extra_files=None, reloader_interval=1,
-               reloader_type='auto', threaded=False, processes=1,
-               request_handler=None, static_files=None,
+               reloader_type='auto', reloader_modules='auto', threaded=False,
+               processes=1, request_handler=None, static_files=None,
                passthrough_errors=False, ssl_context=None):
     """Start a WSGI application. Optional features include a reloader,
     multithreading and fork support.
@@ -567,6 +567,9 @@ def run_simple(hostname, port, application, use_reloader=False,
     :param reloader_type: the type of reloader to use.  The default is
                           auto detection.  Valid values are ``'stat'`` and
                           ``'watchdog'``.
+    :param reloader_modules: modules the reloader should watch.  The default is
+                          to automatically detect files (``'auto'``).
+                          Valid values are ``'auto'`` or a list of paths.
     :param threaded: should the process handle each request in a separate
                      thread?
     :param processes: if greater than 1 then handle each request in a new process
@@ -619,7 +622,7 @@ def run_simple(hostname, port, application, use_reloader=False,
 
         from ._reloader import run_with_reloader
         run_with_reloader(inner, extra_files, reloader_interval,
-                          reloader_type)
+                          reloader_type, reloader_modules)
     else:
         inner()
 

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -524,7 +524,7 @@ def is_running_from_reloader():
 def run_simple(hostname, port, application, use_reloader=False,
                use_debugger=False, use_evalex=True,
                extra_files=None, reloader_interval=1,
-               reloader_type='auto', reloader_modules=None, threaded=False,
+               reloader_type='auto', reloader_paths=None, threaded=False,
                processes=1, request_handler=None, static_files=None,
                passthrough_errors=False, ssl_context=None):
     """Start a WSGI application. Optional features include a reloader,
@@ -567,9 +567,9 @@ def run_simple(hostname, port, application, use_reloader=False,
     :param reloader_type: the type of reloader to use.  The default is
                           auto detection.  Valid values are ``'stat'`` and
                           ``'watchdog'``.
-    :param reloader_modules: modules the reloader should watch.  Defaults to
-                             ``None`` which means automatically detect modules.
-                             Valid values are a list of paths or ``None``.
+    :param reloader_paths: directories the reloader should watch.  Defaults to
+                           ``None`` which means automatically detect modules.
+                           Valid values are a list of paths or ``None``.
     :param threaded: should the process handle each request in a separate
                      thread?
     :param processes: if greater than 1 then handle each request in a new process
@@ -622,7 +622,7 @@ def run_simple(hostname, port, application, use_reloader=False,
 
         from ._reloader import run_with_reloader
         run_with_reloader(inner, extra_files, reloader_interval,
-                          reloader_type, reloader_modules)
+                          reloader_type, reloader_paths)
     else:
         inner()
 


### PR DESCRIPTION
Fixes #662 

Added a `reloader_modules` option to `serving.run_simple`, `_reloader.run_with_reloader` and `ReloaderLoop`. Defaults to `auto` which is the current behavior of watching everything in `sys.path` and `sys.modules`. Let me know if/where I should create a test for this.