### PR TITLE
rv is a set, use add(), not append()

### DIFF
--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -76,7 +76,7 @@ def _find_observable_paths(extra_files=None):
     """Finds all paths that should be observed."""
     rv = set(os.path.abspath(x) for x in sys.path)
     for filename in extra_files or ():
-        rv.append(os.path.dirname(os.path.abspath(filename)))
+        rv.add(os.path.dirname(os.path.abspath(filename)))
     for module in list(sys.modules.values()):
         fn = getattr(module, '__file__', None)
         if fn is None:


### PR DESCRIPTION
When creating a new Werkzeug server you can specify extra paths for the reloader to watch using the ```extra_files``` parameter. Currently this fails in version 0.10, and will continue to fail in future versions since the code uses ```.append()``` not ```.add()``` on ```rv```, which is a ```set()```.