### PR TITLE
Extra files is a set, use add(), not append()

### DIFF
--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -90,7 +90,7 @@ def _find_observable_paths(reloader_paths=None, extra_files=None):
     else:
         rv = set(os.path.abspath(x) for x in reloader_paths)
     for filename in extra_files or ():
-        rv.append(os.path.dirname(os.path.abspath(filename)))
+        rv.add(os.path.dirname(os.path.abspath(filename)))
 
     return rv
 


### PR DESCRIPTION
When creating a new Werkzeug server you can specify extra paths for the reloader to watch using the ```extra_files``` parameter. Currently this fails in version 0.10-maintenance and master, and will continue to fail in future versions since the code uses ```.append()``` not ```.add()``` on ```rv```, which is a ```set()```.