### PR TITLE
MultiDict.update() ignores empty "iterable" values while iterating

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -558,7 +558,23 @@ class MultiDict(TypeConversionDict):
         return dict(self.lists())
 
     def update(self, other_dict):
-        """update() extends rather than replaces existing key lists."""
+        """update() extends rather than replaces existing key lists:
+
+        >>> a = MultiDict({'x': 1})
+        >>> b = MultiDict({'x': 2, 'y': 3})
+        >>> a.update(b)
+        >>> a
+        MultiDict([('y', 3), ('x', 1), ('x', 2)])
+
+        If the value list for a key in ``other_dict`` is empty, no new values
+        will be added to the dict and the key will not be created:
+
+        >>> x = {'empty_list': []}
+        >>> y = MultiDict()
+        >>> y.update(x)
+        >>> y
+        MultiDict([])
+        """
         for key, value in iter_multi_items(other_dict):
             MultiDict.add(self, key, value)
 
@@ -1357,7 +1373,7 @@ class CombinedMultiDict(ImmutableMultiDictMixin, MultiDict):
     def _keys_impl(self):
         """This function exists so __len__ can be implemented more efficiently,
         saving one list creation from an iterator.
-        
+
         Using this for Python 2's ``dict.keys`` behavior would be useless since
         `dict.keys` in Python 2 returns a list, while we have a set here.
         """


### PR DESCRIPTION
I did this to fix flask-restful/flask-restful#380 which has been annoying me for some time.

If you try to call `update` on a `MultiDict` and the mapping passed to `update` has an empty iterable for the value mapped to a key, that value is ignored:

```python
>>> from werkzeug.datastructures import MultiDict
>>> x = {'empty_list': []}
>>> y = MultiDict()
>>> y.update(x)
>>> y
MultiDict([])
>>> y['empty_list'] = []
>>> y
MultiDict([('empty_list', [])])
```

Regular `dict`:
```python
>>> x = {'empty_list': []}
>>> y = {}
>>> y.update(x)
>>> y
{'empty_list': []}
```

I think I read the docs pretty closely and didn't see that ignoring empty iterable values was intentional.