### PR TITLE
Specify pytest collection directory explicitly

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,7 +45,7 @@ install it with::
 
 Then you can run the testsuite with::
 
-    py.test
+    py.test tests
 
 With only py.test installed, a large part of the testsuite will get skipped
 though.  Whether this is relevant depends on which part of Werkzeug you're

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ class TestCommand(Command):
 
     def run(self):
         import pytest
-        pytest.cmdline.main(args=[])
+        pytest.cmdline.main(args=['tests'])
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,4 @@ whitelist_externals=
     memcached
 
 commands=
-    py.test []
+    py.test tests


### PR DESCRIPTION
I usually have my virtualenvs in the project directory. The default test commands will collect tests from the virtualenv directory. Specifying the `tests` directory explicitly prevents that.