### PR TITLE
Make RedisCache work with clients that don't support MULTI

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@ Version 0.11
   default port numbers in ``HTTP_HOST`` (pull request ``#204``).
 - ``BuildErrors`` are now more informative. They come with a complete sentence
   as error message, and also provide suggestions (pull request ``#691``).
+- Fixed issue where RedisCache set_many was broken for twemproxy, which doesn't
+  support the MULTI command (pull request ``#702``).
 
 Version 0.10.x
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -13,10 +13,10 @@ Version 0.11
   Python's ``property`` type (issue ``#616``).
 - ``bind_to_environ`` now doesn't differentiate between implicit and explicit
   default port numbers in ``HTTP_HOST`` (pull request ``#204``).
-- ``BuildErrors`` are now more informative. They come with a complete sentence
-  as error message, and also provide suggestions (pull request ``#691``).
 - Fixed issue where RedisCache set_many was broken for twemproxy, which doesn't
   support the MULTI command (pull request ``#702``).
+- ``BuildErrors`` are now more informative. They come with a complete sentence
+  as error message, and also provide suggestions (pull request ``#691``).
 
 Version 0.10.x
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -14,7 +14,7 @@ Version 0.11
 - ``bind_to_environ`` now doesn't differentiate between implicit and explicit
   default port numbers in ``HTTP_HOST`` (pull request ``#204``).
 - Fixed issue where RedisCache set_many was broken for twemproxy, which doesn't
-  support the MULTI command (pull request ``#702``).
+  support the default MULTI command (pull request ``#702``).
 - ``BuildErrors`` are now more informative. They come with a complete sentence
   as error message, and also provide suggestions (pull request ``#691``).
 

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -571,7 +571,7 @@ class RedisCache(BaseCache):
     def set_many(self, mapping, timeout=None):
         if timeout is None:
             timeout = self.default_timeout
-        pipe = self._client.pipeline()
+        pipe = self._client.pipeline(transaction=False)
         for key, value in _items(mapping):
             dump = self.dump_object(value)
             pipe.setex(name=self.key_prefix + key, value=dump, time=timeout)

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -572,6 +572,8 @@ class RedisCache(BaseCache):
         if timeout is None:
             timeout = self.default_timeout
         pipe = self._client.pipeline(transaction=False)
+        # Use transaction=False to batch without calling redis MULTI
+        # which is not supported by twemproxy
         for key, value in _items(mapping):
             dump = self.dump_object(value)
             pipe.setex(name=self.key_prefix + key, value=dump, time=timeout)


### PR DESCRIPTION
RedisCache:set_many uses pipleline, which in turn uses MULTI redis
command which is not supported by twemproxy. The default transaction
isn’t required, as the pipeline is being used to batch commands and
isn’t relying on transactional semantics.

Fixes https://github.com/mitsuhiko/werkzeug/issues/612