### PR TITLE
Problem with the Safari user agent parsing

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -352,7 +352,7 @@ def test_user_agent_mixin():
          'opera', 'windows', '8.54', 'de-DE'),
         ('Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420 '
          '(KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3',
-         'safari', 'iphone', '419.3', 'en'),
+         'safari', 'iphone', '3.0', 'en'),
         ('Bot Googlebot/2.1 ( http://www.googlebot.com/bot.html)',
          'google', None, '2.1', None),
         ('Mozilla/5.0 (X11; CrOS armv7l 3701.81.0) AppleWebKit/537.31 '

--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -46,7 +46,7 @@ class UserAgentParser(object):
         ('chrome', 'chrome'),
         ('firefox|firebird|phoenix|iceweasel', 'firefox'),
         ('galeon', 'galeon'),
-        ('safari', 'safari'),
+        ('safari|version', 'safari'),
         ('webkit', 'webkit'),
         ('camino', 'camino'),
         ('konqueror', 'konqueror'),


### PR DESCRIPTION
User agents for Safari are a bit different from other UA.
The version is not found in the form <browser>/<version> but in the form Version/<version> Safari/<build number>.
To correctly get the Safari version, we have to apply this small fix, otherwise, we get the build number.