### PR TITLE
Add exists() to contrib.cache

### DIFF
--- a/tests/contrib/test_cache.py
+++ b/tests/contrib/test_cache.py
@@ -139,6 +139,16 @@ class CacheTests(object):
         fast_sleep(timeout + 1)
         assert c.get('foo') is None
 
+    def test_generic_exists(self, c):
+        assert c.exists('foo') in (False, 0)
+        assert c.exists('spam') in (False, 0)
+        assert c.set('foo', 'bar')
+        assert c.exists('foo') in (True, 1)
+        assert c.exists('spam') in (False, 0)
+        c.delete('foo')
+        assert c.exists('foo') in (False, 0)
+        assert c.exists('spam') in (False, 0)
+
 
 class TestSimpleCache(CacheTests):
 


### PR DESCRIPTION
Adds support for checking if a key exists in the cache, using a backend command if possible, eg. EXISTS in Redis otherwise falls back to check if .get(key) is None

Rationale is there are cases when you may want to check if a key exists, but do not want to bring back the data as well (think large objects / bandwidth).

