### PR TITLE
Add uWSGI caching backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 language: python
-python:
-    - "2.6"
-    - "2.7"
-    - "pypy"
-    - "3.3"
-    - "3.4"
-    - "3.5"
+python: 2.7
+env:
+    - TOXENV=py26-normal
+    - TOXENV=py27-normal
+    - TOXENV=pypy-normal
+    - TOXENV=py33-normal
+    - TOXENV=py34-normal
+    - TOXENV=py35-normal
+    - TOXENV=py26-uwsgi
+    - TOXENV=py27-uwsgi
+    - TOXENV=py33-uwsgi
+    - TOXENV=py34-uwsgi
+    - TOXENV=py35-uwsgi
 
 install:
     # Travis uses an outdated PyPy, this installs the most recent one.
     # This makes the tests run on Travis' legacy infrastructure, but so be it.
     # temporary pyenv installation to get pypy-2.6 before container infra upgrade
-    # Taken from pyca/cryptography
-    - if [ "$TRAVIS_PYTHON_VERSION" == "pypy" ]; then
+    - if [ "$TOXENV" == "pypy" ]; then
         git clone https://github.com/yyuu/pyenv.git ~/.pyenv;
         PYENV_ROOT="$HOME/.pyenv";
         PATH="$PYENV_ROOT/bin:$PATH";
@@ -24,7 +29,7 @@ install:
     - pip install tox flake8
 
 script:
-    - tox -e py
+    - tox
     - make stylecheck
 
 branches:

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Unreleased.
 - Added support for status code 451.
 - Improved the build error suggestions.  In particular only if
   someone stringifies the error will the suggestions be calculated.
+- Added support for uWSGI's caching backend.
 
 Version 0.11.4
 --------------

--- a/docs/contrib/cache.rst
+++ b/docs/contrib/cache.rst
@@ -32,3 +32,5 @@ Cache Systems
 .. autoclass:: RedisCache
 
 .. autoclass:: FileSystemCache
+
+.. autoclass:: UWSGICache

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, py33, py34, py35
+envlist = py{26,27,py,33,34,35}-normal, py{26,27,33,34,35}-uwsgi
 
 [testenv]
 passenv = LANG
@@ -12,6 +12,7 @@ deps=
     redis
     requests
     watchdog
+    uwsgi: uwsgi
 
 # Python 2
     py26: python-memcached
@@ -26,6 +27,8 @@ deps=
 whitelist_externals=
     redis-server
     memcached
+    uwsgi
 
 commands=
-    py.test []
+    normal: py.test []
+    uwsgi: uwsgi --pyrun {envbindir}/py.test --pyargv -kUWSGI --cache2=name=werkzeugtest,items=20 --master

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -60,6 +60,7 @@ import os
 import re
 import errno
 import tempfile
+import platform
 from hashlib import md5
 from time import time
 try:
@@ -793,3 +794,62 @@ class FileSystemCache(BaseCache):
                     return False
         except (IOError, OSError, pickle.PickleError):
             return False
+
+class UWSGICache(BaseCache):
+    """ Implements the cache using uWSGI's caching framework.
+
+    .. note::
+        This class cannot be used when running under PyPy, because the uWSGI
+        API implementation for PyPy is lacking the needed functionality.
+
+    :param default_timeout: The default timeout in seconds.
+    :param cache: The name of the caching instance to connect to, for
+        example: mycache@localhost:3031, defaults to an empty string, which
+        means uWSGI will cache in the local instance. If the cache is in the
+        same instance as the werkzeug app, you only have to provide the name of
+        the cache.
+    """
+    def __init__(self, default_timeout=300, cache=''):
+        BaseCache.__init__(self, default_timeout)
+
+        if platform.python_implementation() == 'PyPy':
+            raise RuntimeError("uWSGI caching does not work under PyPy, see "
+                               "the docs for more details.")
+
+        try:
+            import uwsgi
+            self._uwsgi = uwsgi
+        except ImportError:
+            raise RuntimeError("uWSGI could not be imported, are you "
+                                "running under uWSGI?")
+
+        self.cache = cache
+
+    def _get_expiration(self, timeout):
+        if timeout is None:
+            timeout = self.default_timeout
+        return timeout
+
+    def get(self, key):
+        rv = self._uwsgi.cache_get(key, self.cache)
+        if rv is None:
+            return
+        return pickle.loads(rv)
+
+    def delete(self, key):
+        return self._uwsgi.cache_del(key, self.cache)
+
+    def set(self, key, value, timeout=None):
+        return self._uwsgi.cache_update(key, pickle.dumps(value),
+                                        self._get_expiration(timeout),
+                                        self.cache)
+
+    def add(self, key, value, timeout=None):
+        return self._uwsgi.cache_set(key, pickle.dumps(value),
+                                     self._get_expiration(timeout), self.cache)
+
+    def clear(self):
+        return self._uwsgi.cache_clear(self.cache)
+
+    def has(self, key):
+        return self._uwsgi.cache_exists(key, self.cache) is not None


### PR DESCRIPTION
Since version 1.9 uWSGI includes an in-memory cache. Documentation on that can be found at the [uWSGI docs][1].

This PR contains a new UwsgiCache class using uWSGI's `uwsgi.cache_*` functions.

I'm not sure yet about a few things:

1) testing; as `import uwsgi` only works when the app is actually run by uwsgi, writing tests with the actual uwsgi module is basically impossible to my knowledge. Does anyone have an idea on how this could be done?

2) uWSGI also has `cache_inc` and `cache_dec` functions since 1.9.9, but they are not documented, so I'm a bit hesitant on adding them.

3) Naming; is the convention here to use `uWSGICache`, or `UwsgiCache`?

4) Documentation; because I check for the existance of the uwsgi module and only define the actual UwsgiCache class when it exists, sphinx's `automodule` does not pick up on the "real" UwsgiCache class. What's the best way of handling this?

[1]: http://uwsgi-docs.readthedocs.org/en/latest/Caching.html