### PR TITLE
make test Client follow relative redirects

### DIFF
--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -671,7 +671,7 @@ class Client(object):
         cur_server_name = netloc.split(':', 1)[0].split('.')
         real_server_name = get_host(environ).rsplit(':', 1)[0].split('.')
         if cur_server_name == ['']:
-            # this is a local redirect with autocorrect_location_header=False
+            # this is a local redirect having autocorrect_location_header=False
             cur_server_name = real_server_name
             base_url = EnvironBuilder(environ).base_url
 

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -670,6 +670,10 @@ class Client(object):
 
         cur_server_name = netloc.split(':', 1)[0].split('.')
         real_server_name = get_host(environ).rsplit(':', 1)[0].split('.')
+        if cur_server_name == ['']:
+            # this is a local redirect with autocorrect_location_header=False
+            cur_server_name = real_server_name
+            base_url = EnvironBuilder(environ).base_url
 
         if self.allow_subdomain_redirects:
             allowed = cur_server_name[-len(real_server_name):] == real_server_name


### PR DESCRIPTION
v 0.8 introduced BaseResponse attribute `autocorrect_location_header` allowing users to use relative URLs in `Location` header. 

This PR makes testing Client recognize such locations in redirects.