### PR TITLE
Run tests on Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "pypy"
     - "3.3"
     - "3.4"
+    - "3.5"
 
 install:
     # Travis uses an outdated PyPy, this installs the most recent one.

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, py33, py34
+envlist = py26, py27, pypy, py33, py34, py35
 
 [testenv]
 passenv = LANG
@@ -21,6 +21,7 @@ deps=
 # Python 3
     py33: python3-memcached
     py34: python3-memcached
+    py35: python3-memcached
 
 whitelist_externals=
     redis-server


### PR DESCRIPTION
Python 3.5 is out. So time to adapt `tox.ini` and `.tarvis.yml`.