### PR TITLE
Avoid SHA1

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -26,15 +26,15 @@ def test_safe_str_cmp():
 def test_password_hashing():
     hash0 = generate_password_hash('default')
     assert check_password_hash(hash0, 'default')
-    assert hash0.startswith('pbkdf2:sha3:1000$')
+    assert hash0.startswith('pbkdf2:sha384:1000$')
 
-    hash1 = generate_password_hash('default', 'sha3')
-    hash2 = generate_password_hash(u'default', method='sha3')
+    hash1 = generate_password_hash('default', 'sha384')
+    hash2 = generate_password_hash(u'default', method='sha384')
     assert hash1 != hash2
     assert check_password_hash(hash1, 'default')
     assert check_password_hash(hash2, 'default')
-    assert hash1.startswith('sha3$')
-    assert hash2.startswith('sha3$')
+    assert hash1.startswith('sha384$')
+    assert hash2.startswith('sha384$')
 
     fakehash = generate_password_hash('default', method='plain')
     assert fakehash == 'plain$$default'

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -26,15 +26,15 @@ def test_safe_str_cmp():
 def test_password_hashing():
     hash0 = generate_password_hash('default')
     assert check_password_hash(hash0, 'default')
-    assert hash0.startswith('pbkdf2:sha1:1000$')
+    assert hash0.startswith('pbkdf2:sha3:1000$')
 
-    hash1 = generate_password_hash('default', 'sha1')
-    hash2 = generate_password_hash(u'default', method='sha1')
+    hash1 = generate_password_hash('default', 'sha3')
+    hash2 = generate_password_hash(u'default', method='sha3')
     assert hash1 != hash2
     assert check_password_hash(hash1, 'default')
     assert check_password_hash(hash2, 'default')
-    assert hash1.startswith('sha1$')
-    assert hash2.startswith('sha1$')
+    assert hash1.startswith('sha3$')
+    assert hash2.startswith('sha3$')
 
     fakehash = generate_password_hash('default', method='plain')
     assert fakehash == 'plain$$default'

--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -201,7 +201,7 @@ def _hash_internal(method, salt, password):
     return rv, actual_method
 
 
-def generate_password_hash(password, method='pbkdf2:sha1', salt_length=8):
+def generate_password_hash(password, method='pbkdf2:sha384', salt_length=8):
     """Hash a password with the given method and salt with with a string of
     the given length.  The format of the string returned includes the method
     that was used so that :func:`check_password_hash` can check the hash.


### PR DESCRIPTION
Changed the hashing algorithm for the password hashing function and the corresponding tests. Sha1 should not be used anymore.