### PR TITLE
Fix an issue when app.debug is set to True

### DIFF
--- a/werkzeug/debug/__init__.py
+++ b/werkzeug/debug/__init__.py
@@ -93,7 +93,7 @@ def get_pin_and_cookie_name(app):
     if num is None:
         num = ('%09d' % int(h.hexdigest(), 16))[:9]
 
-    h.update('cookiesalt')
+    h.update(b'cookiesalt')
     cookie_name = '__wzd' + h.hexdigest()[:12]
 
     # Format the pincode in groups of digits for easier remembering if


### PR DESCRIPTION
Fix the "Unicode-objects must be encoded before hashing" bug when app.debug is set to True by changing the string to binary