### PR TITLE
Use socket.socket.set_inheritable. Fixes #805

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -662,8 +662,8 @@ def run_simple(hostname, port, application, use_reloader=False,
             s = socket.socket(address_family, socket.SOCK_STREAM)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind((hostname, port))
-            if hasattr(os, 'set_inheritable'):
-                os.set_inheritable(s.fileno(), True)
+            if hasattr(s, 'set_inheritable'):
+                s.set_inheritable(True)
 
             # If we can open the socket by file descriptor, then we can just
             # reuse this one and our socket will survive the restarts.


### PR DESCRIPTION
Use `socket.socket.set_inheritable` instead of `os.set_inheritable`. This better handles situations where `socket.socket.fileno()` returns a handle (e.g. when running in Windows) instead of a file descriptor.

Since both `os.*_inheritable` and `socket.socket.*_inheritable` were added in 3.4.0, compatibility should not be reduced.

Fixes #805