### PR TITLE
Fix for the reloading server on windows.

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -41,6 +41,7 @@ import os
 import socket
 import sys
 import signal
+import platform
 
 try:
     import ssl
@@ -663,7 +664,10 @@ def run_simple(hostname, port, application, use_reloader=False,
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind((hostname, port))
             if hasattr(os, 'set_inheritable'):
-                os.set_inheritable(s.fileno(), True)
+                if platform.system() == 'Windows':
+                    os.set_handle_inheritable(s.fileno(), True)
+                else:
+                    os.set_inheritable(s.fileno(), True)
 
             # If we can open the socket by file descriptor, then we can just
             # reuse this one and our socket will survive the restarts.


### PR DESCRIPTION
  use os.set_handle_inheritable on sockets as os.set_inheritable results in the following stack trace:
  
Traceback (most recent call last):
  File "run.py", line 4, in <module>
    app.run()
  File "C:\Users\Peter Ellis\AppData\Local\Programs\Python\Python35-32\lib\site-packages\flask\app.py", line 772, in run
    run_simple(host, port, self, **options)
  File "C:\Users\Peter Ellis\AppData\Local\Programs\Python\Python35-32\lib\site-packages\werkzeug\serving.py", line 666, in run_simple
    os.set_inheritable(s.fileno(), True)
OSError: [Errno 9] Bad file descriptor