### PR TITLE
Fix Google App Engine import error

### DIFF
--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -162,8 +162,10 @@ def test_custom_idents():
 def test_deepcopy_on_proxy():
     class Foo(object):
         attr = 42
+
         def __copy__(self):
             return self
+
         def __deepcopy__(self, memo):
             return self
     f = Foo()

--- a/werkzeug/debug/__init__.py
+++ b/werkzeug/debug/__init__.py
@@ -72,8 +72,16 @@ def get_pin_and_cookie_name(app):
 
     modname = getattr(app, '__module__',
                       getattr(app.__class__, '__module__'))
+
+    try:
+        # `getpass.getuser()` imports the `pwd` module,
+        # which does not exist in the Google App Engine sandbox.
+        username = getpass.getuser()
+    except ImportError:
+        username = None
+
     bits = [
-        getpass.getuser(),
+        username,
         str(uuid.getnode()),
         modname,
         getattr(app, '__name__', getattr(app.__class__, '__name__')),

--- a/werkzeug/script.py
+++ b/werkzeug/script.py
@@ -317,6 +317,7 @@ def make_runserver(app_factory, hostname='localhost', port=5000,
     :param ssl_context: optional SSL context for running server in HTTPS mode.
     """
     _deprecated()
+
     def action(hostname=('h', hostname), port=('p', port),
                reloader=use_reloader, debugger=use_debugger,
                evalex=use_evalex, threaded=threaded, processes=processes):

--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -211,7 +211,7 @@ def generate_password_hash(password, method='pbkdf2:sha1', salt_length=8):
         method$salt$hash
 
     This method can **not** generate unsalted passwords but it is possible
-    to set param method='plain' in order to enforce plaintext passwords.  
+    to set param method='plain' in order to enforce plaintext passwords.
     If a salt is used, hmac is used internally to salt the password.
 
     If PBKDF2 is wanted it can be enabled by setting the method to

--- a/werkzeug/urls.py
+++ b/werkzeug/urls.py
@@ -41,7 +41,7 @@ _hextobyte = dict(
 
 
 _URLTuple = fix_tuple_repr(namedtuple('_URLTuple',
-    ['scheme', 'netloc', 'path', 'query', 'fragment']))
+                           ['scheme', 'netloc', 'path', 'query', 'fragment']))
 
 
 class BaseURL(_URLTuple):


### PR DESCRIPTION
This PR fixes an import error that occurs within Google App Engine with the latest version of Werkzeug.  This fix is minimal.  However, I've done a little homework and found [an example](https://github.com/google/oauth2client/pull/275/files) of how to incorporate the Google App Engine version of Python into tox tests.

I am currently using `Werkzeug==0.10.4`, which works for my App Engine project.  However, I encountered this error when I used v 0.11.x.