### PR TITLE
Add support for HTTP status code 451

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -43,6 +43,7 @@ def test_proxy_exception():
     (exceptions.RequestURITooLarge, 414),
     (exceptions.UnsupportedMediaType, 415),
     (exceptions.UnprocessableEntity, 422),
+    (exceptions.UnavailableForLegalReasons, 451),
     (exceptions.InternalServerError, 500),
     (exceptions.NotImplemented, 501),
     (exceptions.BadGateway, 502),

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -162,10 +162,13 @@ def test_custom_idents():
 def test_deepcopy_on_proxy():
     class Foo(object):
         attr = 42
+
         def __copy__(self):
             return self
+
         def __deepcopy__(self, memo):
             return self
+
     f = Foo()
     p = local.LocalProxy(lambda: f)
     assert p.attr == 42

--- a/werkzeug/exceptions.py
+++ b/werkzeug/exceptions.py
@@ -515,6 +515,19 @@ class RequestHeaderFieldsTooLarge(HTTPException):
     )
 
 
+class UnavailableForLegalReasons(HTTPException):
+
+    """*451* `Unavailable For Legal Reasons`
+
+    This request may not be serviced due to legal reasons which disallow access
+    to resources hosted on the server.
+    """
+    code = 451
+    description = (
+        'Unavailable for legal reasons.'
+    )
+
+
 class InternalServerError(HTTPException):
 
     """*500* `Internal Server Error`

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -125,6 +125,7 @@ HTTP_STATUS_CODES = {
     429:    'Too Many Requests',
     431:    'Request Header Fields Too Large',
     449:    'Retry With',  # proprietary MS extension
+    451:    'Unavailable For Legal Reasons',
     500:    'Internal Server Error',
     501:    'Not Implemented',
     502:    'Bad Gateway',

--- a/werkzeug/script.py
+++ b/werkzeug/script.py
@@ -317,6 +317,7 @@ def make_runserver(app_factory, hostname='localhost', port=5000,
     :param ssl_context: optional SSL context for running server in HTTPS mode.
     """
     _deprecated()
+
     def action(hostname=('h', hostname), port=('p', port),
                reloader=use_reloader, debugger=use_debugger,
                evalex=use_evalex, threaded=threaded, processes=processes):

--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -211,7 +211,7 @@ def generate_password_hash(password, method='pbkdf2:sha1', salt_length=8):
         method$salt$hash
 
     This method can **not** generate unsalted passwords but it is possible
-    to set param method='plain' in order to enforce plaintext passwords.  
+    to set param method='plain' in order to enforce plaintext passwords.
     If a salt is used, hmac is used internally to salt the password.
 
     If PBKDF2 is wanted it can be enabled by setting the method to

--- a/werkzeug/urls.py
+++ b/werkzeug/urls.py
@@ -40,8 +40,9 @@ _hextobyte = dict(
 )
 
 
-_URLTuple = fix_tuple_repr(namedtuple('_URLTuple',
-    ['scheme', 'netloc', 'path', 'query', 'fragment']))
+_URLTuple = fix_tuple_repr(
+    namedtuple('_URLTuple', ['scheme', 'netloc', 'path', 'query', 'fragment'])
+)
 
 
 class BaseURL(_URLTuple):


### PR DESCRIPTION
Enable support for the newly approved HTTP 451 status code `Unavailable For Legal Reasons` as described by the IETF [here](https://tools.ietf.org/html/draft-ietf-httpbis-legally-restricted-status-04)   
I saw PR [#834](https://github.com/mitsuhiko/werkzeug/pull/834) already covers most of this, however this also updated the `werkzeug.http.HTTP_STATUS_CODES` dict.