### PR TITLE
fix: environ might be missing

### DIFF
--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -162,8 +162,10 @@ def test_custom_idents():
 def test_deepcopy_on_proxy():
     class Foo(object):
         attr = 42
+
         def __copy__(self):
             return self
+
         def __deepcopy__(self, memo):
             return self
     f = Foo()

--- a/werkzeug/local.py
+++ b/werkzeug/local.py
@@ -11,7 +11,7 @@
 import copy
 from functools import update_wrapper
 from werkzeug.wsgi import ClosingIterator
-from werkzeug._compat import PY2, implements_bool
+from werkzeug._compat import PY2, implements_bool, to_unicode
 
 # since each thread has its own greenlet we can just use those as identifiers
 # for the context.  If greenlets are not available we fall back to the
@@ -327,7 +327,7 @@ class LocalProxy(object):
 
     def __unicode__(self):
         try:
-            return unicode(self._get_current_object())  # noqa
+            return to_unicode(self._get_current_object())  # noqa
         except RuntimeError:
             return repr(self)
 

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -309,7 +309,7 @@ class BuildError(RoutingException, LookupError):
         return u''.join(message)
 
     def __str__(self):
-        return unicode(self).encode('utf-8')
+        return to_unicode(self).encode('utf-8')
 
 
 class ValidationError(ValueError):

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -110,7 +110,7 @@ from werkzeug.exceptions import HTTPException, NotFound, MethodNotAllowed, \
 from werkzeug._internal import _get_environ, _encode_idna
 from werkzeug._compat import itervalues, iteritems, to_unicode, to_bytes, \
     text_type, string_types, native_string_result, \
-    implements_to_string, wsgi_decoding_dance
+    implements_to_string, wsgi_decoding_dance, PY2
 from werkzeug.datastructures import ImmutableDict, MultiDict
 from werkzeug.utils import cached_property
 
@@ -309,7 +309,11 @@ class BuildError(RoutingException, LookupError):
         return u''.join(message)
 
     def __str__(self):
-        return to_unicode(self).encode('utf-8')
+        # Recursion issue with to_unicode.
+        # I used "return unicode(self).encode('utf-8') if PY2 else self.__unicode__()"
+        # at the beginning and passed flake8. But when I checked with "make stylecheck",
+        # it failed with "undefined unicode" error. Any idea?
+        return text_type(self).encode('utf-8') if PY2 else self.__unicode__()
 
 
 class ValidationError(ValueError):

--- a/werkzeug/script.py
+++ b/werkzeug/script.py
@@ -317,6 +317,7 @@ def make_runserver(app_factory, hostname='localhost', port=5000,
     :param ssl_context: optional SSL context for running server in HTTPS mode.
     """
     _deprecated()
+
     def action(hostname=('h', hostname), port=('p', port),
                reloader=use_reloader, debugger=use_debugger,
                evalex=use_evalex, threaded=threaded, processes=processes):

--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -211,7 +211,7 @@ def generate_password_hash(password, method='pbkdf2:sha1', salt_length=8):
         method$salt$hash
 
     This method can **not** generate unsalted passwords but it is possible
-    to set param method='plain' in order to enforce plaintext passwords.  
+    to set param method='plain' in order to enforce plaintext passwords.
     If a salt is used, hmac is used internally to salt the password.
 
     If PBKDF2 is wanted it can be enabled by setting the method to

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -263,7 +263,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         return BaseHTTPRequestHandler.version_string(self).strip()
 
     def address_string(self):
-        return self.environ['REMOTE_ADDR']
+        return self.environ['REMOTE_ADDR'] if self.environ else 'localhost'
 
     def log_request(self, code='-', size='-'):
         self.log('info', '"%s" %s %s', self.requestline, code, size)

--- a/werkzeug/urls.py
+++ b/werkzeug/urls.py
@@ -40,8 +40,8 @@ _hextobyte = dict(
 )
 
 
-_URLTuple = fix_tuple_repr(namedtuple('_URLTuple',
-    ['scheme', 'netloc', 'path', 'query', 'fragment']))
+_URLTuple = fix_tuple_repr(
+    namedtuple('_URLTuple', ['scheme', 'netloc', 'path', 'query', 'fragment']))
 
 
 class BaseURL(_URLTuple):


### PR DESCRIPTION
how it happened?
the environ is attached to WSGIRequestHandler object in run_wsgi method. But run_wsgi is only executed after the request is pasted in handle_one_request method. If request is pasted failed and try to send_error message. It will try to call address_string method to get the client address and raise the AttributeError(AttributeError: 'WSGIRequestHandler' object has no attribute 'environ')