### PR TITLE
Fix session can't save to store

### DIFF
--- a/werkzeug/contrib/sessions.py
+++ b/werkzeug/contrib/sessions.py
@@ -167,7 +167,9 @@ class SessionStore(object):
 
     def new(self):
         """Generate a new session."""
-        return self.session_class({}, self.generate_key(), True)
+        session = self.session_class({}, self.generate_key(), True)
+        session.modified = True
+        return session
 
     def save(self, session):
         """Save a session."""


### PR DESCRIPTION
In `SessionMiddleware` when sid is None, execute `new()` will return a session instance, but session.should_save is `False`. so session will never be saved and can not set the cookie. SessionMiddleware is not works