### PR TITLE
Fix incorrect case of weak etag indicator

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -179,23 +179,23 @@ class TestHTTPUtility(object):
 
     def test_etags(self):
         assert http.quote_etag('foo') == '"foo"'
-        assert http.quote_etag('foo', True) == 'w/"foo"'
+        assert http.quote_etag('foo', True) == 'W/"foo"'
         assert http.unquote_etag('"foo"') == ('foo', False)
-        assert http.unquote_etag('w/"foo"') == ('foo', True)
-        es = http.parse_etags('"foo", "bar", w/"baz", blar')
+        assert http.unquote_etag('W/"foo"') == ('foo', True)
+        es = http.parse_etags('"foo", "bar", W/"baz", blar')
         assert sorted(es) == ['bar', 'blar', 'foo']
         assert 'foo' in es
         assert 'baz' not in es
         assert es.contains_weak('baz')
         assert 'blar' in es
-        assert es.contains_raw('w/"baz"')
+        assert es.contains_raw('W/"baz"')
         assert es.contains_raw('"foo"')
-        assert sorted(es.to_header().split(', ')) == ['"bar"', '"blar"', '"foo"', 'w/"baz"']
+        assert sorted(es.to_header().split(', ')) == ['"bar"', '"blar"', '"foo"', 'W/"baz"']
 
     def test_etags_nonzero(self):
-        etags = http.parse_etags('w/"foo"')
+        etags = http.parse_etags('W/"foo"')
         assert bool(etags)
-        assert etags.contains_raw('w/"foo"')
+        assert etags.contains_raw('W/"foo"')
 
     def test_parse_date(self):
         assert http.parse_date('Sun, 06 Nov 1994 08:49:37 GMT    ') == datetime(
@@ -380,7 +380,7 @@ class TestRange(object):
         assert rv.to_header() == '"Test"'
 
         # weak information is dropped
-        rv = http.parse_if_range_header('w/"Test"')
+        rv = http.parse_if_range_header('W/"Test"')
         assert rv.etag == 'Test'
         assert rv.date is None
         assert rv.to_header() == '"Test"'

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -345,8 +345,8 @@ def test_accept_mixin():
 def test_etag_request_mixin():
     request = wrappers.Request({
         'HTTP_CACHE_CONTROL':       'no-store, no-cache',
-        'HTTP_IF_MATCH':            'w/"foo", bar, "baz"',
-        'HTTP_IF_NONE_MATCH':       'w/"foo", bar, "baz"',
+        'HTTP_IF_MATCH':            'W/"foo", bar, "baz"',
+        'HTTP_IF_NONE_MATCH':       'W/"foo", bar, "baz"',
         'HTTP_IF_MODIFIED_SINCE':   'Tue, 22 Jan 2008 11:18:44 GMT',
         'HTTP_IF_UNMODIFIED_SINCE': 'Tue, 22 Jan 2008 11:18:44 GMT'
     })
@@ -355,7 +355,7 @@ def test_etag_request_mixin():
 
     for etags in request.if_match, request.if_none_match:
         assert etags('bar')
-        assert etags.contains_raw('w/"foo"')
+        assert etags.contains_raw('W/"foo"')
         assert etags.contains_weak('foo')
         assert not etags.contains('foo')
 

--- a/werkzeug/contrib/lint.py
+++ b/werkzeug/contrib/lint.py
@@ -276,7 +276,10 @@ class LintMiddleware(object):
     def check_headers(self, headers):
         etag = headers.get('etag')
         if etag is not None:
-            if etag.startswith('w/'):
+            if etag.startswith(('W/', 'w/')):
+                if etag.startswith('w/'):
+                    warn(HTTPWarning('weak etag indicator should be upcase.'),
+                         stacklevel=4)
                 etag = etag[2:]
             if not (etag[:1] == etag[-1:] == '"'):
                 warn(HTTPWarning('unquoted etag emitted.'), stacklevel=4)

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -2160,7 +2160,7 @@ class ETags(object):
             return '*'
         return ', '.join(
             ['"%s"' % x for x in self._strong] +
-            ['w/"%s"' % x for x in self._weak]
+            ['W/"%s"' % x for x in self._weak]
         )
 
     def __call__(self, etag=None, data=None, include_weak=False):

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -628,14 +628,14 @@ def quote_etag(etag, weak=False):
         raise ValueError('invalid etag')
     etag = '"%s"' % etag
     if weak:
-        etag = 'w/' + etag
+        etag = 'W/' + etag
     return etag
 
 
 def unquote_etag(etag):
     """Unquote a single etag:
 
-    >>> unquote_etag('w/"bar"')
+    >>> unquote_etag('W/"bar"')
     ('bar', True)
     >>> unquote_etag('"bar"')
     ('bar', False)
@@ -647,7 +647,7 @@ def unquote_etag(etag):
         return None, None
     etag = etag.strip()
     weak = False
-    if etag[:2] in ('w/', 'W/'):
+    if etag.startswith(('W/', 'w/')):
         weak = True
         etag = etag[2:]
     if etag[:1] == etag[-1:] == '"':

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -308,8 +308,9 @@ class BuildError(RoutingException, LookupError):
                 )
         return u''.join(message)
 
+    @native_string_result
     def __str__(self):
-        return unicode(self).encode('utf-8')
+        return self.__unicode__()
 
 
 class ValidationError(ValueError):

--- a/werkzeug/script.py
+++ b/werkzeug/script.py
@@ -317,6 +317,7 @@ def make_runserver(app_factory, hostname='localhost', port=5000,
     :param ssl_context: optional SSL context for running server in HTTPS mode.
     """
     _deprecated()
+
     def action(hostname=('h', hostname), port=('p', port),
                reloader=use_reloader, debugger=use_debugger,
                evalex=use_evalex, threaded=threaded, processes=processes):

--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -211,7 +211,7 @@ def generate_password_hash(password, method='pbkdf2:sha1', salt_length=8):
         method$salt$hash
 
     This method can **not** generate unsalted passwords but it is possible
-    to set param method='plain' in order to enforce plaintext passwords.  
+    to set param method='plain' in order to enforce plaintext passwords.
     If a salt is used, hmac is used internally to salt the password.
 
     If PBKDF2 is wanted it can be enabled by setting the method to


### PR DESCRIPTION
According to http://tools.ietf.org/html/rfc7232#section-2.3
weakness must be specified via `W/` (note "case-sensitive").
Werkzeug's use of `w/` causes strict reverse proxies such as
CloudFlare to drop the ETag header entirely.