### PR TITLE
fix(routing): match when server_name have port

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1305,7 +1305,7 @@ class Map(object):
 
         if subdomain is None and not self.host_matching:
             cur_server_name = wsgi_server_name.split('.')
-            real_server_name = server_name.split('.')
+            real_server_name = server_name.split(':')[0].split('.')
             offset = -len(real_server_name)
             if cur_server_name[offset:] != real_server_name:
                 # This can happen even with valid configs if the server was


### PR DESCRIPTION
if `server_name` includes port then `real_server_name` will be for example `['127', '0', '0', '1:83']` so it won't match with `cur_server_name[-4:]` (`['127', '0', '0', '1']`) so `subdomain` will be `<invalid>` and every URL will be returning `404`